### PR TITLE
Add backwards compatible support for Erlang/OTP 24

### DIFF
--- a/lib/mongo.ex
+++ b/lib/mongo.ex
@@ -343,7 +343,11 @@ defmodule Mongo do
   @doc false
   @spec count(GenServer.server(), collection, BSON.document(), Keyword.t()) ::
           result(non_neg_integer)
-  def count(topology_pid, coll, filter, opts \\ []) do
+  def count(topology_pid, coll, filter, opts \\ [])
+
+  def count(topology_pid, coll, filter, opts) when is_list(filter), do: count(topology_pid, coll, filter |> Enum.into(%{}), opts)
+
+  def count(topology_pid, coll, filter, opts) do
     query =
       filter_nils(
         count: coll,

--- a/lib/mongo/pbkdf2.ex
+++ b/lib/mongo/pbkdf2.ex
@@ -64,7 +64,11 @@ defmodule Mongo.PBKDF2 do
     iterate(fun, iteration - 1, next, :crypto.exor(next, acc))
   end
 
-  defp mac_fun(digest, secret) do
-    &:crypto.hmac(digest, secret, &1)
+  if Code.ensure_loaded?(:crypto) and function_exported?(:crypto, :mac, 4) do
+    # Supports Erlang / OTP v24 and above
+    defp mac_fun(digest, secret), do: &:crypto.mac(:hmac, digest, secret, &1)
+  else
+    # Supports Erlang / OTP older than v24
+    defp mac_fun(digest, secret), do: &:crypto.hmac(digest, secret, &1)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -43,9 +43,9 @@ defmodule Mongodb.Mixfile do
 
   defp deps do
     [
-      {:db_connection, "~> 2.0"},
-      {:decimal, "~> 1.5"},
-      {:jason, "~> 1.0", only: :test},
+      {:db_connection, "~> 2.4.0"},
+      {:decimal, "~> 2.0"},
+      {:jason, "~> 1.2.2", only: :test},
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:earmark, ">= 0.0.0", only: :dev},
       {:dialyxir, "~> 1.1.0", only: :dev, runtime: false}

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
   "connection": {:hex, :connection, "1.1.0", "ff2a49c4b75b6fb3e674bfc5536451607270aac754ffd1bdfe175abe4a6d7a68", [:mix], [], "hexpm", "722c1eb0a418fbe91ba7bd59a47e28008a189d47e37e0e7bb85585a016b2869c"},
   "db_connection": {:hex, :db_connection, "2.4.0", "d04b1b73795dae60cead94189f1b8a51cc9e1f911c234cc23074017c43c031e5", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}, {:telemetry, "~> 0.4 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "ad416c21ad9f61b3103d254a71b63696ecadb6a917b36f563921e0de00d7d7c8"},
-  "decimal": {:hex, :decimal, "1.9.0", "83e8daf59631d632b171faabafb4a9f4242c514b0a06ba3df493951c08f64d07", [:mix], [], "hexpm", "b1f2343568eed6928f3e751cf2dffde95bfaa19dd95d09e8a9ea92ccfd6f7d85"},
+  "decimal": {:hex, :decimal, "2.0.0", "a78296e617b0f5dd4c6caf57c714431347912ffb1d0842e998e9792b5642d697", [:mix], [], "hexpm", "34666e9c55dea81013e77d9d87370fe6cb6291d1ef32f46a1600230b1d44f577"},
   "dialyxir": {:hex, :dialyxir, "1.1.0", "c5aab0d6e71e5522e77beff7ba9e08f8e02bad90dfbeffae60eaf0cb47e29488", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "07ea8e49c45f15264ebe6d5b93799d4dd56a44036cf42d0ad9c960bc266c0b9a"},
   "earmark": {:hex, :earmark, "1.4.10", "bddce5e8ea37712a5bfb01541be8ba57d3b171d3fa4f80a0be9bcf1db417bcaf", [:mix], [{:earmark_parser, ">= 1.4.10", [hex: :earmark_parser, repo: "hexpm", optional: false]}], "hexpm", "12dbfa80810478e521d3ffb941ad9fbfcbbd7debe94e1341b4c4a1b2411c1c27"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.10", "6603d7a603b9c18d3d20db69921527f82ef09990885ed7525003c7fe7dc86c56", [:mix], [], "hexpm", "8e2d5370b732385db2c9b22215c3f59c84ac7dda7ed7e544d7c459496ae519c0"},

--- a/test/mongo/config_hide_test.exs
+++ b/test/mongo/config_hide_test.exs
@@ -2,8 +2,6 @@ defmodule Mongo.HideConfigTest do
   use ExUnit.Case, async: true
   alias Mongo.ConfigHide
 
-  @password_masked "***"
-
   setup_all do
     :ok
   end

--- a/test/mongo/encoder_test.exs
+++ b/test/mongo/encoder_test.exs
@@ -65,7 +65,7 @@ defmodule Mongo.EncoderTest do
   test "insert encoded struct without protocol" do
     pid = connect_auth()
     coll = unique_name()
-    {:ok, conn, _, _} = Mongo.select_server(pid, :write)
+    {:ok, _conn, _, _} = Mongo.select_server(pid, :write)
 
     struct_to_insert = %CustomStructWithoutProtocol{a: 10, b: 20, c: 30, id: "x"}
 

--- a/test/mongo/session_test.exs
+++ b/test/mongo/session_test.exs
@@ -20,7 +20,7 @@ defmodule Mongo.SessionTest do
 
   describe "lifetime" do
     test "session can be created", %{pid: pid} do
-      assert {:ok, session} = Mongo.start_session(pid)
+      assert {:ok, _session} = Mongo.start_session(pid)
     end
 
     test "created session is not ended", %{pid: pid} do

--- a/test/mongo/url_parser_test.exs
+++ b/test/mongo/url_parser_test.exs
@@ -15,7 +15,7 @@ defmodule Mongo.UrlParserTest do
 
       opts = UrlParser.parse_url(url: url)
       password = Keyword.get(opts, :password)
-      assert password = "2yPK}Bzj|qE($^1JDdk4J42*&4lLgV%C"
+      assert password == "2yPK}Bzj|qE($^1JDdk4J42*&4lLgV%C"
     end
 
     test "cluster url" do

--- a/test/mongo_test.exs
+++ b/test/mongo_test.exs
@@ -642,13 +642,9 @@ defmodule Mongo.Test do
   @tag :mongo_3_4
   test "correctly query NumberDecimal", c do
     coll = "number_decimal_test"
+    decimal = Decimal.new("123.456")
 
-    Mongo.command(
-      c.pid,
-      %{
-        eval: "db.#{coll}.insert({number: NumberDecimal('123.456')})"
-      }
-    )
+    Mongo.insert_one(c.pid, coll, %{number: decimal})
 
     assert %{"number" => %Decimal{coef: 123_456, exp: -3}} =
              Mongo.find(c.pid, coll, %{}, limit: 1) |> Enum.to_list() |> List.first()

--- a/test/mongo_test.exs
+++ b/test/mongo_test.exs
@@ -130,7 +130,7 @@ defmodule Mongo.Test do
   test "count", c do
     coll = unique_name()
 
-    assert {:ok, 0} = Mongo.count(c.pid, coll, %{})
+    assert {:ok, 0} = Mongo.count(c.pid, coll, [])
 
     assert {:ok, _} = Mongo.insert_one(c.pid, coll, %{foo: 42})
     assert {:ok, _} = Mongo.insert_one(c.pid, coll, %{foo: 43})

--- a/test/mongo_test.exs
+++ b/test/mongo_test.exs
@@ -130,7 +130,7 @@ defmodule Mongo.Test do
   test "count", c do
     coll = unique_name()
 
-    assert {:ok, 0} = Mongo.count(c.pid, coll, [])
+    assert {:ok, 0} = Mongo.count(c.pid, coll, %{})
 
     assert {:ok, _} = Mongo.insert_one(c.pid, coll, %{foo: 42})
     assert {:ok, _} = Mongo.insert_one(c.pid, coll, %{foo: 43})


### PR DESCRIPTION
Adds backwards compatible support for Erlang/OTP 24 by conditionally defining functions based on presence of `:crypto.mac/4` (introduced in v24).

I was thinking of introducing a common interface to the `:crypto` module that would take care of the differences in APIs in v24, but in the end I opted for the quicker option which seems fine for now.